### PR TITLE
[Fix] Explicitly bake TD to "td_vis" vertex color layer

### DIFF
--- a/Texel_Density_2024_1_Bl410/viz_operators.py
+++ b/Texel_Density_2024_1_Bl410/viz_operators.py
@@ -599,7 +599,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 						color = utils.Value_To_Color(face_td_area_list[face_id][0], bake_vc_min_td, bake_vc_max_td)
 
 						for loop in bm.faces[face_id].loops:
-							loop[bm.loops.layers.color.active] = color
+							loop[bm.loops.layers.color.get("td_vis")] = color
 
 				# Assign random color for each island
 				elif td.bake_vc_mode == "UV_ISLANDS_TO_VC":
@@ -612,7 +612,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 
 						for face_id in uv_island:
 							for loop in bm.faces[face_id].loops:
-								loop[bm.loops.layers.color.active] = color4
+								loop[bm.loops.layers.color.get("td_vis")] = color4
 
 				# Calculate and assign color from UV area to VC for each island (UV areas sum of polygons of island)
 				elif td.bake_vc_mode == "UV_SPACE_TO_VC":
@@ -627,7 +627,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 
 						for face_id in uv_island:
 							for loop in bm.faces[face_id].loops:
-								loop[bm.loops.layers.color.active] = color
+								loop[bm.loops.layers.color.get("td_vis")] = color
 
 				# Calculate and assign color from TD to VC for each island (average TD between polygons of island)
 				elif td.bake_vc_mode == "TD_ISLANDS_TO_VC":
@@ -650,7 +650,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 
 						for face_id in uv_island:
 							for loop in bm.faces[face_id].loops:
-								loop[bm.loops.layers.color.active] = color
+								loop[bm.loops.layers.color.get("td_vis")] = color
 
 				elif td.bake_vc_mode == 'DISTORTION':
 					uv_area_total = 0
@@ -685,7 +685,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 						color = utils.Value_To_Color(uv_percent / geom_percent, min_range, max_range)
 
 						for loop in bm.faces[face_id].loops:
-							loop[bm.loops.layers.color.active] = color
+							loop[bm.loops.layers.color.get("td_vis")] = color
 
 				bpy.ops.object.mode_set(mode='OBJECT')
 


### PR DESCRIPTION
When baking texel density to vertex colors, I found that the bake always went to the first color layer. It might be a bug with bmesh, but getting "bm.loops.layers.color.active" does not return "td_vis" even when set explicitly with "x.data.vertex_colors["td_vis"].active = True" in line 597. It returns the first layer in the list. 

If "td_vis" is the first color attribute added to the mesh, this will be no issue, since it will always be the first layer in the data. However, with meshes that already have vertex color data, the first channel will always be the one that gets written to. 

Again, this may be a bug within Bmesh API itself, but in the meantime, we can get around this by writing directly to "bm.loops.layers.color.get("td_vis")" instead of the current active color layer. 

[Bmesh Layer Collection Reference](https://docs.blender.org/api/current/bmesh.types.html#bmesh.types.BMLayerCollection) 