### PR TITLE
Feature: More Bake VC colorization methods

### DIFF
--- a/Texel_Density_2025_1_Bl420/props.py
+++ b/Texel_Density_2025_1_Bl420/props.py
@@ -276,7 +276,7 @@ draw_info = {
 
 
 def Is_Colorization_Showable(enum_value):
-    return enum_value == "TD_COLORIZE_HUE" or enum_value == "TD_COLORIZE_GRAYSCALE"
+    return enum_value == "TD_COLORIZE_HUE" or enum_value == "TD_COLORIZE_GRAYSCALE_LINEAR" or enum_value == "TD_COLORIZE_GRAYSCALE_SQRT"
 
 
 def Show_Gradient(self, context):
@@ -395,7 +395,8 @@ class TD_Addon_Props(bpy.types.PropertyGroup):
 	bake_vc_mode: EnumProperty(name="", items=bake_vc_mode_list, update=Change_Bake_VC_Mode)
 
 	bake_vc_colorization_list = (('TD_COLORIZE_HUE', 'RGB Hue', ''),
-								 ('TD_COLORIZE_GRAYSCALE', 'Grayscale', ''),
+								 ('TD_COLORIZE_GRAYSCALE_LINEAR', 'Grayscale (Linear)', ''),
+								 ('TD_COLORIZE_GRAYSCALE_SQRT', 'Grayscale (Square Root)', ''),
 								 ('TD_COLORIZE_FIXED24_RGB8', 'Normalized 24-Bit Fixed-Point (RGB8)', ''))
 	bake_vc_colorization: EnumProperty(name="", items=bake_vc_colorization_list, update=Change_Bake_VC_Colorization)
 

--- a/Texel_Density_2025_1_Bl420/props.py
+++ b/Texel_Density_2025_1_Bl420/props.py
@@ -394,10 +394,10 @@ class TD_Addon_Props(bpy.types.PropertyGroup):
 						 ('DISTORTION', 'UV Distortion', ''))
 	bake_vc_mode: EnumProperty(name="", items=bake_vc_mode_list, update=Change_Bake_VC_Mode)
 
-	bake_vc_colorization_list = (('TD_COLORIZE_HUE', 'RGB Hue', ''),
-								 ('TD_COLORIZE_GRAYSCALE_LINEAR', 'Grayscale (Linear)', ''),
-								 ('TD_COLORIZE_GRAYSCALE_SQRT', 'Grayscale (Square Root)', ''),
-								 ('TD_COLORIZE_FIXED24_RGB8', 'Normalized 24-Bit Fixed-Point (RGB8)', ''))
+	bake_vc_colorization_list = (('TD_COLORIZE_HUE', 'RGB Hue', 'Bake fully saturated colors into VC.\nCalculated values are mapped to the colors\' hue.'),
+								 ('TD_COLORIZE_GRAYSCALE_LINEAR', 'Grayscale (Linear)', 'Bake grayscale colors into VC.\nCalculated values are mapped to the colors\' value (brightness).'),
+								 ('TD_COLORIZE_GRAYSCALE_SQRT', 'Grayscale (Square Root)', 'Bake grayscale colors into VC.\nCalculated values are first taken the square root of, then mapped to the colors\' value (brightness).'),
+								 ('TD_COLORIZE_FIXED24_RGB8', 'Normalized 24-Bit Fixed-Point (RGB8)', 'Bake values directly into VC.\nCalculated values are normalized (i.e. scaled to range 0 to 1) and converted to 24-bit fixed-point numbers, then bitwise-split into 3 channels and converted to floating-point RGB colors, resulting in non-color RGB values in the final VC.\nData can be recovered with expression: `((round(R * 255.0) << 16) + (round(G * 255.0) << 8) + round(B * 255.0)) / float(0xffffff)`, which gives you the normalized value. To retrieve the original, unnormalized value, you\'ll need to memorize the Min and Max value (displayed above), in some way that suits your need, then scale back manually.'))
 	bake_vc_colorization: EnumProperty(name="", items=bake_vc_colorization_list, update=Change_Bake_VC_Colorization)
 
 	bake_vc_min_space: StringProperty(

--- a/Texel_Density_2025_1_Bl420/props.py
+++ b/Texel_Density_2025_1_Bl420/props.py
@@ -245,7 +245,7 @@ def Filter_Select_Threshold(self, context):
 def Change_Bake_VC_Mode(self, context):
 	td = context.scene.td
 
-	if td.bake_vc_mode == "TD_FACES_TO_VC" or td.bake_vc_mode == "TD_ISLANDS_TO_VC" or td.bake_vc_mode == "UV_SPACE_TO_VC":
+	if td.bake_vc_mode == "TD_FACES_TO_VC" or td.bake_vc_mode == "TD_ISLANDS_TO_VC" or td.bake_vc_mode == "UV_SPACE_TO_VC" or td.bake_vc_mode == "DISTORTION":
 		Show_Gradient(self, context)
 	else:
 		bpy.types.SpaceView3D.draw_handler_remove(draw_info["handler"], 'WINDOW')

--- a/Texel_Density_2025_1_Bl420/props.py
+++ b/Texel_Density_2025_1_Bl420/props.py
@@ -255,6 +255,11 @@ def Change_Bake_VC_Mode(self, context):
 		bpy.ops.object.bake_td_uv_to_vc()
 
 
+def Change_Bake_VC_Colorization(self, context):
+    # Basically do the same as if Bake VC Mode has been changed
+	Change_Bake_VC_Mode(self, context)
+
+
 def Change_Select_Mode(self, context):
 	if utils.Get_Preferences().automatic_recalc:
 		bpy.ops.object.select_by_td_space()
@@ -270,12 +275,17 @@ draw_info = {
 }
 
 
+def Is_Colorization_Showable(enum_value):
+    return enum_value == "TD_COLORIZE_HUE" or enum_value == "TD_COLORIZE_GRAYSCALE"
+
+
 def Show_Gradient(self, context):
 	td = context.scene.td
-	if td.bake_vc_show_gradient and draw_info["handler"] is None:
+	should_show = td.bake_vc_show_gradient and Is_Colorization_Showable(td.bake_vc_colorization)
+	if should_show and draw_info["handler"] is None:
 		draw_info["handler"] = bpy.types.SpaceView3D.draw_handler_add(viz_operators.Draw_Callback_Px, (None, None),
 																	  'WINDOW', 'POST_PIXEL')
-	elif (not td.bake_vc_show_gradient) and draw_info["handler"] is not None:
+	elif (not should_show) and draw_info["handler"] is not None:
 		bpy.types.SpaceView3D.draw_handler_remove(draw_info["handler"], 'WINDOW')
 		draw_info["handler"] = None
 
@@ -383,6 +393,11 @@ class TD_Addon_Props(bpy.types.PropertyGroup):
 						 ('UV_SPACE_TO_VC', 'UV Space (%)', ''),
 						 ('DISTORTION', 'UV Distortion', ''))
 	bake_vc_mode: EnumProperty(name="", items=bake_vc_mode_list, update=Change_Bake_VC_Mode)
+
+	bake_vc_colorization_list = (('TD_COLORIZE_HUE', 'RGB Hue', ''),
+								 ('TD_COLORIZE_GRAYSCALE', 'Grayscale', ''),
+								 ('TD_COLORIZE_FIXED24_RGB8', 'Normalized 24-Bit Fixed-Point (RGB8)', ''))
+	bake_vc_colorization: EnumProperty(name="", items=bake_vc_colorization_list, update=Change_Bake_VC_Colorization)
 
 	bake_vc_min_space: StringProperty(
 		name="",

--- a/Texel_Density_2025_1_Bl420/ui.py
+++ b/Texel_Density_2025_1_Bl420/ui.py
@@ -1,5 +1,6 @@
 import bpy
 from . import utils
+from . import props
 
 
 # Panel in 3D View
@@ -202,7 +203,11 @@ class VIEW3D_PT_texel_density_checker(bpy.types.Panel):
 				row.prop(td, "bake_vc_max_td")
 
 				row = box.row()
+				row.label(text="Colorization:")
+				row.prop(td, "bake_vc_colorization", expand=False)
+				row = box.row()
 				row.prop(td, "bake_vc_show_gradient", text="Show Gradient")
+				row.active = props.Is_Colorization_Showable(td.bake_vc_colorization)
 				row = box.row()
 				row.operator("object.bake_td_uv_to_vc", text="Texel Density to VC")
 
@@ -224,7 +229,11 @@ class VIEW3D_PT_texel_density_checker(bpy.types.Panel):
 				row.prop(td, "bake_vc_max_space")
 
 				row = box.row()
+				row.label(text="Colorization:")
+				row.prop(td, "bake_vc_colorization", expand=False)
+				row = box.row()
 				row.prop(td, "bake_vc_show_gradient", text="Show Gradient")
+				row.active = props.Is_Colorization_Showable(td.bake_vc_colorization)
 				row = box.row()
 				row.operator("object.bake_td_uv_to_vc", text="UV Space to VC")
 
@@ -235,7 +244,11 @@ class VIEW3D_PT_texel_density_checker(bpy.types.Panel):
 				row.label(text=" %")
 
 				row = box.row()
+				row.label(text="Colorization:")
+				row.prop(td, "bake_vc_colorization", expand=False)
+				row = box.row()
 				row.prop(td, "bake_vc_show_gradient", text="Show Gradient")
+				row.active = props.Is_Colorization_Showable(td.bake_vc_colorization)
 				row = box.row()
 				row.operator("object.bake_td_uv_to_vc", text="UV Distortion to VC")
 

--- a/Texel_Density_2025_1_Bl420/utils.py
+++ b/Texel_Density_2025_1_Bl420/utils.py
@@ -7,6 +7,7 @@ import ctypes
 import ctypes.util
 import numpy as np
 import sys
+import math
 
 
 def Normalize_Value(value, range_min, range_max):
@@ -28,9 +29,15 @@ def Value_To_Color(value, range_min, range_max):
 	return color4
 
 
-# Value to grayscale Color
-def Value_To_Grayscale(value, range_min, range_max):
+# Value to linear grayscale Color
+def Value_To_Grayscale_Linear(value, range_min, range_max):
 	remapped_value = Normalize_Value(value, range_min, range_max)
+	return (remapped_value, remapped_value, remapped_value, 1.0)
+
+
+# Value to linear grayscale Color
+def Value_To_Grayscale_Sqrt(value, range_min, range_max):
+	remapped_value = math.sqrt(Normalize_Value(value, range_min, range_max))
 	return (remapped_value, remapped_value, remapped_value, 1.0)
 
 

--- a/Texel_Density_2025_1_Bl420/viz_operators.py
+++ b/Texel_Density_2025_1_Bl420/viz_operators.py
@@ -501,6 +501,17 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 		start_time = datetime.now()
 		td = context.scene.td
 
+		# Determine the colorization method to use:
+		if td.bake_vc_colorization == "TD_COLORIZE_HUE":
+			colorize = utils.Value_To_Color
+		elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE":
+			colorize = utils.Value_To_Grayscale
+		elif td.bake_vc_colorization == "TD_COLORIZE_FIXED24_RGB8":
+			colorize = utils.Value_To_Fixed24
+		else:
+			self.report({'ERROR'}, "Invalid VC colorization method \"%s\"" % td.bake_vc_colorization)
+			return {'CANCELLED'}
+
 		# Save current mode and active object
 		start_active_obj = bpy.context.active_object
 		start_mode = bpy.context.object.mode
@@ -596,7 +607,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 				# Calculate and assign color from TD to VC for each polygon
 				if td.bake_vc_mode == "TD_FACES_TO_VC":
 					for face_id in range(0, face_count):
-						color = utils.Value_To_Color(face_td_area_list[face_id * 2], bake_vc_min_td, bake_vc_max_td)
+						color = colorize(face_td_area_list[face_id * 2], bake_vc_min_td, bake_vc_max_td)
 
 						for loop in bm.faces[face_id].loops:
 							loop[bm.loops.layers.color.get("td_vis")] = color
@@ -623,7 +634,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 
 						# Convert island area value to percentage of area
 						island_area *= 100
-						color = utils.Value_To_Color(island_area, bake_vc_min_space, bake_vc_max_space)
+						color = colorize(island_area, bake_vc_min_space, bake_vc_max_space)
 
 						for face_id in uv_island:
 							for loop in bm.faces[face_id].loops:
@@ -646,7 +657,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 						for face_id in uv_island:
 							island_td += face_td_area_list[face_id * 2] * face_td_area_list[face_id * 2 + 1] / island_area
 
-						color = utils.Value_To_Color(island_td, bake_vc_min_td, bake_vc_max_td)
+						color = colorize(island_td, bake_vc_min_td, bake_vc_max_td)
 
 						for face_id in uv_island:
 							for loop in bm.faces[face_id].loops:
@@ -682,7 +693,7 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 						uv_percent = face_td_area_list[face_id * 2 + 1] / uv_area_total
 						geom_percent = geom_area_list[face_id] / geom_area_total
 
-						color = utils.Value_To_Color(uv_percent / geom_percent, min_range, max_range)
+						color = colorize(uv_percent / geom_percent, min_range, max_range)
 
 						for loop in bm.faces[face_id].loops:
 							loop[bm.loops.layers.color.get("td_vis")] = color

--- a/Texel_Density_2025_1_Bl420/viz_operators.py
+++ b/Texel_Density_2025_1_Bl420/viz_operators.py
@@ -153,11 +153,19 @@ def Draw_Callback_Px(self, context):
 						(r * blendColor4 + y * (1 - blendColor4)) * step(pos.x, pos_x_max) * step(pos_x_75, pos.x);
 	}
 		'''
-	elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE":
+	elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE_LINEAR":
 		fshader_src += '''
 	void main()
 	{
 		float pos_x_normalized = (pos.x - pos_x_min) / (pos_x_max - pos_x_min);
+		FragColor = vec4(pos_x_normalized, pos_x_normalized, pos_x_normalized, 1.0f);
+	}
+		'''
+	elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE_SQRT":
+		fshader_src += '''
+	void main()
+	{
+		float pos_x_normalized = sqrt((pos.x - pos_x_min) / (pos_x_max - pos_x_min));
 		FragColor = vec4(pos_x_normalized, pos_x_normalized, pos_x_normalized, 1.0f);
 	}
 		'''
@@ -523,8 +531,10 @@ class Bake_TD_UV_to_VC(bpy.types.Operator):
 		# Determine the colorization method to use:
 		if td.bake_vc_colorization == "TD_COLORIZE_HUE":
 			colorize = utils.Value_To_Color
-		elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE":
-			colorize = utils.Value_To_Grayscale
+		elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE_LINEAR":
+			colorize = utils.Value_To_Grayscale_Linear
+		elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE_SQRT":
+			colorize = utils.Value_To_Grayscale_Sqrt
 		elif td.bake_vc_colorization == "TD_COLORIZE_FIXED24_RGB8":
 			colorize = utils.Value_To_Fixed24
 		else:

--- a/Texel_Density_2025_1_Bl420/viz_operators.py
+++ b/Texel_Density_2025_1_Bl420/viz_operators.py
@@ -118,12 +118,14 @@ def Draw_Callback_Px(self, context):
 	}
 	''')
 
-	shader_info.fragment_source('''
+	fshader_src = '''
 	//uniform float pos_x_min;
 	//uniform float pos_x_max;
 
 	//in vec3 pos;
-
+	'''
+	if td.bake_vc_colorization == "TD_COLORIZE_HUE":
+		fshader_src += '''
 	void main()
 	{
 		// Pure Colors
@@ -150,7 +152,24 @@ def Draw_Callback_Px(self, context):
 						(y * blendColor3 + g * (1 - blendColor3)) * step(pos.x, pos_x_75) * step(pos_x_50, pos.x) +
 						(r * blendColor4 + y * (1 - blendColor4)) * step(pos.x, pos_x_max) * step(pos_x_75, pos.x);
 	}
-	''')
+		'''
+	elif td.bake_vc_colorization == "TD_COLORIZE_GRAYSCALE":
+		fshader_src += '''
+	void main()
+	{
+		float pos_x_normalized = (pos.x - pos_x_min) / (pos_x_max - pos_x_min);
+		FragColor = vec4(pos_x_normalized, pos_x_normalized, pos_x_normalized, 1.0f);
+	}
+		'''
+	else:
+		#FUTURE: elif and attach F shader for more colorization?
+		fshader_src += '''
+	void main()
+	{
+		FragColor = vec4(1.0f, 0.0f, 1.0f, 1.0f);
+	}
+		'''
+	shader_info.fragment_source(fshader_src)
 
 	# Gradient Bounds with range 0.0 - 2.0
 	gradient_x_min = screen_texel_x * offset_x


### PR DESCRIPTION
1. Implement basic support for changeable VC calculation methods
2. Adds 3 new colorization: grayscale (linear), grayscale (square root) and fixed-point non-color

## Motivation

I'm using the addon to calculate TD and bake into VC, so I can use that data in the game engine. Currently the color is calculated with a fixed method that maps the calculated value to a hue (`utils.Value_To_Color`), which I believe is perfect for visualization, but not quite suitable for real-time applications as decoding the mapped color involves RGB to HSV transformation.

## Contents

I'm making this PR so the VC calculation ("colorization") method can be chosen from a range of methods. This involves adding one property (`props.TD_Addon_Props.bake_vc_colorization`) and minor logic tweaks. Original work (the value-to-hue method) is not changed in any way and has become the default.

3 more colorization methods are also implemented:

**Grayscale (Linear)**, calculated values are mapped to the colors' brightness:

![01](https://github.com/user-attachments/assets/1bff56db-e32a-4fe6-a08b-d27afc104c6d)

**Grayscale (Square Root)**, calculated values are first taken the square root of, then mapped to the colors' brightness:

![02](https://github.com/user-attachments/assets/3d0160c5-ff68-4347-8252-2ca01ac65528)

**Normalized 24-Bit Fixed-Point (RGB8)**, which bakes values directly into VC; offers higher precision than grayscale methods, at the cost of readability and slightly heavier decoding:

> Calculated values are normalized and converted to 24-bit fixed-point numbers, then bitwise-split into 3 channels and converted to floating-point RGB colors, resulting in non-color RGB values in the final VC.
> 
> Data can be recovered with expression:
> 
> ```python
> ((round(R * 255.0) << 16) + (round(G * 255.0) << 8) + round(B * 255.0)) / float(0xffffff)
> ```
> 
> , which evaluates to the normalized value. To retrieve the original, unnormalized value, users will need to scale back using the Min and Max values, which the addon offers.

![03](https://github.com/user-attachments/assets/0d46eaf5-2e5d-4836-8849-7379432e06c2)
