### PR TITLE
Additional presets for small texture sizes.

### DIFF
--- a/texel_density_2025_1_2/constants.py
+++ b/texel_density_2025_1_2/constants.py
@@ -40,8 +40,11 @@ TD_ANCHOR_ORIGIN_ITEMS = (('SELECTION', 'Selection', ''),
                           ('UV_RIGHT_TOP', 'UV Right Top', ''),
                           ('2D_CURSOR', '2D Cursor', ''))
 
-TD_TEXTURE_SIZE_ITEMS = (('512', '512px', ''),
-                        ('1024', '1024px', ''),
+TD_TEXTURE_SIZE_ITEMS = (('64', '64px', ''),
+                        ('128', '128px', ''),
+                        ('256', '256px', ''),
+                        ('512', '512px', ''),                        
+						('1024', '1024px', ''),
                         ('2048', '2048px', ''),
                         ('4096', '4096px', ''),
                         ('CUSTOM', 'Custom', ''))


### PR DESCRIPTION
Achieving a consistent texel density can still be useful when working with small texture sizes, particularly when creating retro-style assets.

To make this easier, additional presets have been added:
- `64px * 64px`
- `128px * 128px`
- `256px * 256px`